### PR TITLE
Credentials for admin account changed

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -37,4 +37,9 @@ GitLab's default administrator account details are below; be sure to login immed
     admin@local.host
     5iveL!fe
 
+Or
+    root
+    5iveL!fe
+  
+
 If you'd like additional assistance editing your hosts file, please read [How do I modify my hosts file?](http://www.rackspace.com/knowledge_center/article/how-do-i-modify-my-hosts-file) from Rackspace.


### PR DESCRIPTION
It seems that the ansible-galaxy role for gitlab changed the username from admin@local.host to root. Since it took me some time to figure out why I couldn't login to a fresh version of gitlab, I added the change to the README
