### PR TITLE
Missing hostname in hosts file.

### DIFF
--- a/elk/provisioning/web/playbook.yml
+++ b/elk/provisioning/web/playbook.yml
@@ -31,5 +31,5 @@
       lineinfile:
         dest: /etc/hosts
         regexp: '.*logs$'
-        line: "192.168.9.90"
+        line: "192.168.9.90 logs"
         state: present


### PR DESCRIPTION
**hostname** is missing in **line** parameter of **Ensure logs server is in hosts file** task.