### PR TITLE
PHP install fails on lamp example

### DIFF
--- a/lamp/Vagrantfile
+++ b/lamp/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "geerlingguy/ubuntu1404"
+  config.vm.box = "geerlingguy/ubuntu1604"
   config.ssh.insert_key = false
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
This is due to 14.04 not being supported by the latest php role (at least I think). Works fine on your 16.04 image.