### PR TITLE
simplify the installation process by using galaxy_role_file command 

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/docker/Vagrantfile
+++ b/docker/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Enable provisioning with Ansible.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "provisioning/main.yml"
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/drupal/Vagrantfile
+++ b/drupal/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/elk/README.md
+++ b/elk/README.md
@@ -19,7 +19,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://ansibleworks.com/) ([guide for installing Ansible](http://docs.ansible.com/intro_installation.html))
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. 5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create both new VMs and configure them.
 

--- a/elk/Vagrantfile
+++ b/elk/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "provisioning/elk/playbook.yml"
       ansible.inventory_path = "provisioning/elk/inventory"
       ansible.sudo = true
+      ansible.galaxy_role_file = "requirements.yml"
     end
   end
 
@@ -35,6 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "provisioning/web/playbook.yml"
       ansible.inventory_path = "provisioning/web/inventory"
       ansible.sudo = true
+      ansible.galaxy_role_file = "requirements.yml"
     end
   end
 

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/gitlab/Vagrantfile
+++ b/gitlab/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/gluster/README.md
+++ b/gluster/README.md
@@ -7,8 +7,7 @@ This project creates a distributed filesystem on two servers using [GlusterFS](h
   1. Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
   2. Download and install [Vagrant](http://www.vagrantup.com/downloads.html).
   3. [Mac/Linux only] Install [Ansible](http://docs.ansible.com/intro_installation.html).
-  4. Run `ansible-galaxy install -r requirements.yml` in this directory to get the required Ansible roles.
-  5. Run `vagrant up` to build the VMs and configure the infrastructure.
+  4. Run `vagrant up` to build the VMs and configure the infrastructure.
 
 When Vagrant is finished provisioning the VMs with Ansible, run the following two commands to confirm that Gluster is operating nominally:
 

--- a/gluster/Vagrantfile
+++ b/gluster/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure("2") do |config|
           ansible.playbook = "playbooks/provision.yml"
           ansible.inventory_path = "inventory"
           ansible.limit = "all"
+          ansible.galaxy_role_file = "requirements.yml"
         end
       end
     end

--- a/gogs/README.md
+++ b/gogs/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://ansibleworks.com/) ([guide for installing Ansible](http://docs.ansible.com/intro_installation.html))
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/gogs/Vagrantfile
+++ b/gogs/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/jenkins/Vagrantfile
+++ b/jenkins/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/lamp/README.md
+++ b/lamp/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/lamp/Vagrantfile
+++ b/lamp/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/lemp/README.md
+++ b/lemp/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/lemp/Vagrantfile
+++ b/lemp/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/munin/README.md
+++ b/munin/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/munin/Vagrantfile
+++ b/munin/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://ansibleworks.com/) ([guide for installing Ansible](http://docs.ansible.com/intro_installation.html))
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/nodejs/Vagrantfile
+++ b/nodejs/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/phergie/README.md
+++ b/phergie/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/phergie/Vagrantfile
+++ b/phergie/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/rails/README.md
+++ b/rails/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/rails/Vagrantfile
+++ b/rails/Vagrantfile
@@ -27,5 +27,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 end

--- a/solr/README.md
+++ b/solr/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/solr/Vagrantfile
+++ b/solr/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/sonarqube/Vagrantfile
+++ b/sonarqube/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/svn/README.md
+++ b/svn/README.md
@@ -16,7 +16,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/svn/Vagrantfile
+++ b/svn/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end

--- a/svn2git/README.md
+++ b/svn2git/README.md
@@ -18,7 +18,6 @@ To use the vagrant file, you will need to have done the following:
   2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html)
   3. Install [Ansible](http://docs.ansible.com/intro_installation.html)
   4. Open a shell prompt (Terminal app on a Mac) and cd into the folder containing the `Vagrantfile`
-  5. Run the following command to install the necessary Ansible roles for this profile: `$ ansible-galaxy install -r requirements.yml`
 
 Once all of that is done, you can simply type in `vagrant up`, and Vagrant will create a new VM, install the base box, and configure it.
 

--- a/svn2git/Vagrantfile
+++ b/svn2git/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure("2") do |config|
     ansible.playbook = "provisioning/playbook.yml"
     ansible.inventory_path = "provisioning/inventory"
     ansible.sudo = true
+    ansible.galaxy_role_file = "requirements.yml"
   end
 
 end


### PR DESCRIPTION
vagrant has the possibility to install directly from the Galaxy role file (https://www.vagrantup.com/docs/provisioning/ansible_common.html#galaxy_role_file)

It saves a step from the manual installation step.

I've been interested by Jenkins, but let me know if you want me to review the other files from the repo and I could update if you're ok.

Great job with the ansible roles and those example files