### PR TITLE
Increase Vagrant VM memory.

### DIFF
--- a/awx/Vagrantfile
+++ b/awx/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.insert_key = false
 
   config.vm.provider :virtualbox do |v|
-    v.memory = 1024
+    v.memory = 4096
     v.cpus = 2
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--ioapic", "on"]


### PR DESCRIPTION
Vagrant awx VM not performant with 1GB of memory. Increase to awx recommended 4GB.