### PR TITLE
Current version of pip package is just docker not docker-py

### DIFF
--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -11,7 +11,8 @@
     awx_version: "devel"
     nodejs_version: "6.x"
     pip_install_packages:
-      - name: docker-py
+      - name: docker
+      - name: docker-compose
 
   roles:
     - geerlingguy.repo-epel


### PR DESCRIPTION
It looks like the current version name of the pip package is just "docker" and attempting to build with "docker-py" results in both the newer "docker" and older "docker-py" packages being installed, and then pip gives a warning that they *must both* be uninstalled, and only one reinstalled. Seems like it should be smarter, but there you have it.

In addition, switching to the "docker" package name leaves me with an error that "docker-compose" is missing. I'm not sure why it doesn't get installed automatically, but specifying it explicitly seems to work.

A possibly better fix would be to simply try installing only "docker-compose" which would *hopefully* pull in the newer "docker" package as a requirement and all would be well. I haven't tested this approach.