### PR TITLE
Adding docker-compose via pip, required for AWX

### DIFF
--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -10,6 +10,7 @@
   vars:
     awx_version: "devel"
     nodejs_version: "6.x"
+    docker_compose_version: "1.27.4"
     pip_install_packages:
       - name: docker
     docker_users:

--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -12,6 +12,7 @@
     nodejs_version: "6.x"
     pip_install_packages:
       - name: docker
+      - name: docker-compose
 
   roles:
     - geerlingguy.repo-epel

--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -12,7 +12,8 @@
     nodejs_version: "6.x"
     pip_install_packages:
       - name: docker
-      - name: docker-compose
+    docker_users:
+      - vagrant
 
   roles:
     - geerlingguy.repo-epel

--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -10,9 +10,9 @@
   vars:
     awx_version: "devel"
     nodejs_version: "6.x"
-    docker_compose_version: "1.27.4"
     pip_install_packages:
       - name: docker
+      - name: docker-compose
     docker_users:
       - vagrant
 

--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -10,6 +10,7 @@
   vars:
     awx_version: "devel"
     nodejs_version: "6.x"
+    docker_install_compose: false
     pip_install_packages:
       - name: docker
       - name: docker-compose


### PR DESCRIPTION
1. Added docker-compose to list of pip installs

I do see you have a docker-compose install task utilized with AWX, but for whatever reason it doesn't install docker-compose properly (?) and I need to install it with pip in order for AWX install to complete. 

Related to PR: https://github.com/geerlingguy/ansible-role-awx/pull/35